### PR TITLE
ESI endpoint changed 

### DIFF
--- a/esi/app_settings.py
+++ b/esi/app_settings.py
@@ -23,7 +23,7 @@ ESI_ALWAYS_CREATE_TOKEN = getattr(settings, 'ESI_ALWAYS_CREATE_TOKEN', False)
 ESI_CACHE_RESPONSE = getattr(settings, 'ESI_CACHE_RESPONSE', True)
 
 # These probably won't ever change. Override if needed.
-ESI_API_URL = getattr(settings, 'ESI_API_URL', 'https://esi.tech.ccp.is/')
+ESI_API_URL = getattr(settings, 'ESI_API_URL', 'https://esi.evetech.net/')
 ESI_OAUTH_LOGIN_URL = getattr(settings, 'ESI_SSO_LOGIN_URL', ESI_OAUTH_URL + "/authorize/")
 ESI_TOKEN_URL = getattr(settings, 'ESI_CODE_EXCHANGE_URL', ESI_OAUTH_URL + "/token")
 ESI_TOKEN_VERIFY_URL = getattr(settings, 'ESI_TOKEN_EXCHANGE_URL', ESI_OAUTH_URL + "/verify")


### PR DESCRIPTION
You might have noticed, the ESI endpoint changed. That was not ideally documented but just on #tweetfleet, cf. https://twitter.com/TeamTechCo/status/992049219056812032

When CCP dropped the DNS records for the old endpoint temporarily, the API was not accessible. See this summary on reddit: 
https://www.reddit.com/r/Eve/comments/a7sc0pccp_removes_redirect_from_old_httpsesitechccpis/

As far as I can see, *app_settings.py* is the only file that needs to be patched in this project for mitigation.